### PR TITLE
Fix bssid parsing

### DIFF
--- a/warmap.go
+++ b/warmap.go
@@ -262,15 +262,15 @@ func findConvexHull(points Points) Points {
 
 //parseBssid takes a filename or comma seperated list of BSSIDs
 //and outputs an array containing the parsed BSSIDs
-func parseBssid(bssids string) (tempBssidSlice []string) {
-	var bssidSlice []string
+func parseBssid(bssids string) []string {
+	var (
+		bssidSlice     []string
+		tempBssidSlice []string
+	)
 	r, err := regexp.Compile("(([a-zA-Z0-9]{2}:)){5}[a-zA-Z0-9]{2}")
 	checkError(err)
-	if _, err := os.Stat(bssids); os.IsNotExist(err) {
-		bssidSlice = strings.Split(bssids, ",")
-	} else {
-		file, err := os.Open(bssids)
-		checkError(err)
+	file, err := os.Open(bssids)
+	if err == nil {
 		defer file.Close()
 		var lines []string
 		scanner := bufio.NewScanner(file)
@@ -279,6 +279,8 @@ func parseBssid(bssids string) (tempBssidSlice []string) {
 			lines = append(lines, scanner.Text())
 		}
 		bssidSlice = lines
+	} else {
+		bssidSlice = strings.Split(bssids, ",")
 	}
 	for i := 0; i < len(bssidSlice); i++ {
 		if r.MatchString(bssidSlice[i]) {
@@ -288,7 +290,7 @@ func parseBssid(bssids string) (tempBssidSlice []string) {
 	if len(tempBssidSlice) == 0 {
 		log.Fatal("Looks like you didn't have any correctly formatted SSIDs")
 	}
-	return
+	return tempBssidSlice
 }
 
 //genHeatmap generates a string to insert a list of heatmap objects


### PR DESCRIPTION
When using a comma separated bssid arg the program would try to open it
as a file and fail. This has been fixed by trying to open the file. If
the file exists it proceeds if not it tries to split on commas.

Also fixed bssids not returning in slice format